### PR TITLE
Update delete_honeypot.sh

### DIFF
--- a/delete_honeypot.sh
+++ b/delete_honeypot.sh
@@ -63,8 +63,12 @@ sudo ip addr delete "${external_ip}/${netmask_prefix}" dev enp4s2
 
 # Stop data collection background processes
 container_code=${honeypot: -1}
-dataJobNum=$(ps aux | grep "malware_monitoring.sh" | grep "HRServe$container_code" | awk '{ print $2 }')
-sudo kill -9 %${dataJobNum}
+dataJobNum=$(ps aux | grep "malware_monitoring.sh" | grep "HRServe$container_code" | awk '{ print $2 }' | sed -n 1p)
+
+while [ $dataJobNum != "" ] ; do
+  sudo kill -9 %${dataJobNum}
+  dataJobNum=$(ps aux | grep "malware_monitoring.sh" | grep "HRServe$container_code" | awk '{ print $2 }' | sed -n 1p)
+done
 echo "Malware monitoring stopped"
 
 


### PR DESCRIPTION
update command to kill malware monitoring script on container deletion so that it kills all processes instead of just 1