### PR TITLE
Error fixes

### DIFF
--- a/monitor-mitm.sh
+++ b/monitor-mitm.sh
@@ -41,13 +41,13 @@ while read line; do
     sudo iptables -A INPUT -s "$attacker_ip" -d "$host_ip" -p tcp --destination-port "$mitm_port" -j ACCEPT
     sudo iptables -A INPUT -d "$host_ip" -p tcp --destination-port "$mitm_port" -j DROP
   elif [[ "$line" == *"Attacker closed connection"* ]]; then
-    ps -aux | grep "sudo tail -f $1" | awk '{ print $2 }' | sed '$ d' | sudo xargs kill
+    ps -aux | grep "tail -f $1" | awk '{ print $2 }' | sed '$ d' | sudo xargs kill
     break
   elif [[ "$start_time" != "0" ]]; then
     curr_time=$(echo "$line" | cut -d ' ' -f 1-2 | sed 's/ /T/')
     # Force honeypot reset if attacker does not leave after 3 hours
     if [ $(( $(date -d "$curr_time" +%s) - $(date -d "$start_time" +%s) )) -ge 10800 ]; then
-      ps -aux | grep "sudo tail -f $1" | awk '{ print $2 }' | sed '$ d' | sudo xargs kill
+      ps -aux | grep "tail -f $1" | awk '{ print $2 }' | sed '$ d' | sudo xargs kill
       break
     fi
   fi


### PR DESCRIPTION
fixes various issues on `monitor-mitm.sh` (update to #14 and #19)
- fixed the blocking other IPs part so that it actually works
- fixed the symlink part to add to the right directory and not happen too early
- updated the kill part so that it kills all `tail` processes associated with this script (instead of just 1)
- fixed an incorrect variable name