### PR TITLE
add man and zip

### DIFF
--- a/install_services.sh
+++ b/install_services.sh
@@ -17,3 +17,6 @@ sudo lxc-attach -n $1 -- apt-get install wget -y
 sudo lxc-attach -n $1 -- apt-get install curl -y
 
 sudo lxc-attach -n $1 -- apt-get install openssh-server -y
+
+sudo lxc-attach -n $1 -- apt-get install man -y 
+sudo lxc-attach -n $1 -- apt-get install zip -y 


### PR DESCRIPTION
Added `man` and `zip` to install-services so that they'll be installed on a template when it's created. Note: these services were manually installed on our existing templates. This update is in case we need to recreate our templates for any reason.