### PR TITLE
Update timer.sh

### DIFF
--- a/timer.sh
+++ b/timer.sh
@@ -18,4 +18,4 @@ ps -aux | grep "monitor-mitm.sh $1" |  awk '{ print $2 }' | sed '$ d' | xargs ki
 # end stuff
 sudo iptables -D INPUT -s "$attacker_ip" -d "$host_ip" -p tcp --destination-port "$mitm_port" -j ACCEPT
 sudo iptables -D INPUT -d "$host_ip" -p tcp --destination-port "$mitm_port" -j REJECT
-sudo bash recycle_honeypot_aux.sh "$container"
+sudo bash recycle_honeypot_aux.sh "$container" 1


### PR DESCRIPTION
We didn't update the `recycle_honeypot_aux` call, which meant it was missing an argument, so the timer wasn't causing recycle. Closes #48.