### PR TITLE
Add time for malware

### DIFF
--- a/malware_monitoring.sh
+++ b/malware_monitoring.sh
@@ -14,7 +14,7 @@ sudo inotifywait -q -m $download_dir -e create |
   while read dir action file; do
     if [ "$action" = "CREATE" ]
     then
-      sleep 20
+      sleep 60
       #add malware id to end
       copyfile="$2$file-$3$count"
       #remove executable

--- a/monitor-mitm.sh
+++ b/monitor-mitm.sh
@@ -50,6 +50,9 @@ if [ "$valid_data" -eq 1 ]; then
 
   # After attacker leaves, reset networking rules and recycle container
   sudo iptables -D INPUT -s "$attacker_ip" -d "$host_ip" -p tcp --destination-port "$mitm_port" -j ACCEPT
+  
+  sleep 600
+  
   sudo iptables -D INPUT -d "$host_ip" -p tcp --destination-port "$mitm_port" -j REJECT
 fi 
 

--- a/timer.sh
+++ b/timer.sh
@@ -18,6 +18,9 @@ ps -aux | grep "monitor-mitm.sh $1" |  awk '{ print $2 }' | sed '$ d' | xargs ki
 
 # end stuff
 sudo iptables -D INPUT -s "$attacker_ip" -d "$host_ip" -p tcp --destination-port "$mitm_port" -j ACCEPT
+
+sleep 600
+
 sudo iptables -D INPUT -d "$host_ip" -p tcp --destination-port "$mitm_port" -j REJECT
 
 echo "[$(date +"%F %H:%M:%S")] Calling recycling script from timer"


### PR DESCRIPTION
add 10 minutes of buffer time for monitor mitm/timer so allow for all malware to be copied properly over to the .downloads folder, 1 minute for malware monitoring